### PR TITLE
Add DCAT RDF Harvester to the enabled plugins

### DIFF
--- a/.env.civity
+++ b/.env.civity
@@ -81,7 +81,7 @@ NGINX_PORT=80
 NGINX_SSLPORT=443
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view recline_view pdf_view datastore portal workflow datapusher scheming_datasets scheming_organizations dcat harvest fairdatapointharvester healthri matomo"
+CKAN__PLUGINS="envvars image_view text_view recline_view pdf_view datastore portal workflow datapusher scheming_datasets scheming_organizations dcat harvest fairdatapointharvester healthri matomo dcat_rdf_harvester"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
Enable the DCAT RDF Harvester to the Health-RI instance, so they can setup more harvesters.